### PR TITLE
Inlined modal controller constructors to support minification

### DIFF
--- a/entity/templates/public/js/entity/_entity-controller.js
+++ b/entity/templates/public/js/entity/_entity-controller.js
@@ -51,7 +51,7 @@ angular.module('<%= baseName %>')
       $scope.open = function (id) {
         var <%= name %>Save = $modal.open({
           templateUrl: '<%= name %>-save.html',
-          controller: <%= _.capitalize(name) %>SaveController,
+          controller: '<%= _.capitalize(name) %>SaveController',
           resolve: {
             <%= name %>: function () {
               return $scope.<%= name %>;
@@ -64,24 +64,23 @@ angular.module('<%= baseName %>')
           $scope.save(id);
         });
       };
+    }])
+  .controller('<%= _.capitalize(name) %>SaveController', ['$scope', '$modalInstance', '<%= name %>',
+    function ($scope, $modalInstance, <%= name %>) {
+      $scope.<%= name %> = <%= name %>;
+
+      <% _.each(attrs, function (attr) { if (attr.attrType === 'Date') { %>
+      $scope.<%= attr.attrName %>DateOptions = {
+        dateFormat: 'yy-mm-dd',
+        <% if (attr.dateConstraint === 'Past') { %>maxDate: -1<% } %>
+        <% if (attr.dateConstraint === 'Future') { %>minDate: 1<% } %>
+      };<% }}); %>
+
+      $scope.ok = function () {
+        $modalInstance.close($scope.<%= name %>);
+      };
+
+      $scope.cancel = function () {
+        $modalInstance.dismiss('cancel');
+      };
     }]);
-
-var <%= _.capitalize(name) %>SaveController =
-  function ($scope, $modalInstance, <%= name %>) {
-    $scope.<%= name %> = <%= name %>;
-
-    <% _.each(attrs, function (attr) { if (attr.attrType === 'Date') { %>
-    $scope.<%= attr.attrName %>DateOptions = {
-      dateFormat: 'yy-mm-dd',
-      <% if (attr.dateConstraint === 'Past') { %>maxDate: -1<% } %>
-      <% if (attr.dateConstraint === 'Future') { %>minDate: 1<% } %>
-    };<% }}); %>
-
-    $scope.ok = function () {
-      $modalInstance.close($scope.<%= name %>);
-    };
-
-    $scope.cancel = function () {
-      $modalInstance.dismiss('cancel');
-    };
-  };


### PR DESCRIPTION
Modal controllers broke after minification because Angular didn't know which dependencies they needed once their parameter names had been minified. I switched them to Angular's inline syntax, specifying their dependencies as strings to support minification.
